### PR TITLE
Rescan permission & cd exc. fix

### DIFF
--- a/src/main/java/com/songoda/skyblock/command/CommandManager.java
+++ b/src/main/java/com/songoda/skyblock/command/CommandManager.java
@@ -21,7 +21,12 @@ import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.command.*;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
@@ -145,16 +150,24 @@ public class CommandManager implements CommandExecutor, TabCompleter {
                     sendConsoleHelpCommands(sender);
                 } else {
                     String commandToExecute;
+                    String defaultCommand;
                     if (plugin.getIslandManager().getIsland(player) == null) {
-                        commandToExecute = mainConfig.getString("Command.Island.Aliases.NoIsland", "island create");
+                        defaultCommand = "island create";
+                        commandToExecute = mainConfig.getString("Command.Island.Aliases.NoIsland", defaultCommand);
                     } else {
-                        commandToExecute = mainConfig.getString("Command.Island.Aliases.IslandOwned", "island controlpanel");
+                        defaultCommand = "island controlpanel";
+                        commandToExecute = mainConfig.getString("Command.Island.Aliases.IslandOwned", defaultCommand);
                     }
-    
-                    if(commandToExecute.startsWith("/")) {
+
+                    if (commandToExecute.trim().equalsIgnoreCase("island") || commandToExecute.trim().equalsIgnoreCase("is")) {
+                        commandToExecute = defaultCommand;
+                        Bukkit.getLogger().warning("Cannot redirect /island to /island or /is, would result in an endless loop. Using the default.");
+                    }
+
+                    if (commandToExecute.startsWith("/")) {
                         commandToExecute = commandToExecute.substring(1);
                     }
-                    
+
                     String finalCommandToExecute = commandToExecute;
                     Bukkit.getServer().getScheduler().runTask(plugin, () ->
                             Bukkit.getServer().dispatchCommand(sender,
@@ -408,7 +421,7 @@ public class CommandManager implements CommandExecutor, TabCompleter {
 
         if (nextEndIndex <= -7) {
             plugin.getMessageManager().sendMessage(player, configLoad.getString("Command.Island.Help.Page.Message"));
-            plugin.getSoundManager().playSound(player,  CompatibleSound.ENTITY_VILLAGER_NO.getSound(), 1.0F, 1.0F);
+            plugin.getSoundManager().playSound(player, CompatibleSound.ENTITY_VILLAGER_NO.getSound(), 1.0F, 1.0F);
 
             return;
         }

--- a/src/main/java/com/songoda/skyblock/cooldown/CooldownTask.java
+++ b/src/main/java/com/songoda/skyblock/cooldown/CooldownTask.java
@@ -3,6 +3,7 @@ package com.songoda.skyblock.cooldown;
 import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class CooldownTask extends BukkitRunnable {
@@ -20,7 +21,7 @@ public class CooldownTask extends BukkitRunnable {
 
             if (cooldownPlayers == null) return;
 
-            for (CooldownPlayer cooldownPlayer : cooldownPlayers) {
+            for (CooldownPlayer cooldownPlayer : new ArrayList<>(cooldownPlayers)) {
                 Cooldown cooldown = cooldownPlayer.getCooldown();
 
                 cooldown.setTime(cooldown.getTime() - 1);
@@ -29,7 +30,6 @@ public class CooldownTask extends BukkitRunnable {
                     cooldownManager.deletePlayer(cooldownType, Bukkit.getServer().getOfflinePlayer(cooldownPlayer.getUUID()));
                 }
             }
-
         }
     }
 }

--- a/src/main/java/com/songoda/skyblock/menus/Levelling.java
+++ b/src/main/java/com/songoda/skyblock/menus/Levelling.java
@@ -4,7 +4,6 @@ import com.songoda.core.compatibility.CompatibleMaterial;
 import com.songoda.core.compatibility.CompatibleSound;
 import com.songoda.skyblock.SkyBlock;
 import com.songoda.skyblock.config.FileManager;
-import com.songoda.skyblock.config.FileManager.Config;
 import com.songoda.skyblock.cooldown.Cooldown;
 import com.songoda.skyblock.cooldown.CooldownManager;
 import com.songoda.skyblock.cooldown.CooldownPlayer;
@@ -32,7 +31,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 
-import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -207,8 +205,9 @@ public class Levelling {
         int playerMenuPage = playerData.getPage(MenuType.LEVELLING), nextEndIndex = islandMaterials.size() - playerMenuPage * 36;
 
         nInv.addItem(nInv.createItem(CompatibleMaterial.OAK_FENCE_GATE.getItem(), configLoad.getString("Menu.Levelling.Item.Exit.Displayname"), null, null, null, null), 0, 8);
-        nInv.addItem(nInv.createItem(CompatibleMaterial.FIREWORK_STAR.getItem(), configLoad.getString("Menu.Levelling.Item.Rescan.Displayname"), configLoad.getStringList("Menu.Levelling.Item.Rescan.Lore"), null, null,
-                new ItemFlag[]{ItemFlag.HIDE_POTION_EFFECTS}), 3, 5);
+        if (player.hasPermission("fabledskyblock.island.level.rescan"))
+            nInv.addItem(nInv.createItem(CompatibleMaterial.FIREWORK_STAR.getItem(), configLoad.getString("Menu.Levelling.Item.Rescan.Displayname"), configLoad.getStringList("Menu.Levelling.Item.Rescan.Lore"), null, null,
+                    new ItemFlag[]{ItemFlag.HIDE_POTION_EFFECTS}), 3, 5);
         nInv.addItem(
                 nInv.createItem(new ItemStack(Material.PAINTING), configLoad.getString("Menu.Levelling.Item.Statistics.Displayname"), configLoad.getStringList("Menu.Levelling.Item.Statistics.Lore"),
                         new Placeholder[]{new Placeholder("%level_points", NumberUtil.formatNumberByDecimal(level.getPoints())), new Placeholder("%level", NumberUtil.formatNumberByDecimal(level.getLevel()))}, null, null),
@@ -274,14 +273,14 @@ public class Levelling {
                 is.setAmount(Math.min(Math.toIntExact(materialAmount), 64));
                 is.setType(CompatibleMaterial.getMaterial(is).getMaterial());
 
-                 long finalMaterialAmountCounted = materialAmountCounted;
+                long finalMaterialAmountCounted = materialAmountCounted;
                 List<String> lore = configLoad.getStringList("Menu.Levelling.Item.Material.Lore");
                 lore.replaceAll(x -> x.replace("%points", NumberUtil.formatNumberByDecimal(pointsEarned)).replace("%blocks", NumberUtil.formatNumberByDecimal(materialAmount))
                         .replace("%material", name).replace("%counted", NumberUtil.formatNumberByDecimal(finalMaterialAmountCounted)));
 
                 nInv.addItem(nInv.createItem(is, configLoad.getString("Menu.Levelling.Item.Material.Displayname").replace("%points", NumberUtil.formatNumberByDecimal(pointsEarned))
-                        .replace("%blocks", NumberUtil.formatNumberByDecimal(materialAmount)).replace("%material", name).replace("%counted", NumberUtil.formatNumberByDecimal(finalMaterialAmountCounted))
-                        ,lore, null, null, null), inventorySlot);
+                                .replace("%blocks", NumberUtil.formatNumberByDecimal(materialAmount)).replace("%material", name).replace("%counted", NumberUtil.formatNumberByDecimal(finalMaterialAmountCounted))
+                        , lore, null, null, null), inventorySlot);
 
             }
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,13 +4,13 @@ version: maven-version-number
 api-version: 1.13
 description: A unique SkyBlock plugin
 author: Songoda
-authors: [Fabrimat]
-softdepend: [HolographicDisplays, Holograms, CMI, PlaceholderAPI, MVdWPlaceholderAPI, Vault, Reserve, PlayerPoints,
-             LeaderHeads, EpicSpawners, UltimateStacker, WorldEdit, Residence, CoreProtect, CMIEInjector]
-loadbefore: [Multiverse-Core, ProtocolLib]
+authors: [ Fabrimat ]
+softdepend: [ HolographicDisplays, Holograms, CMI, PlaceholderAPI, MVdWPlaceholderAPI, Vault, Reserve, PlayerPoints,
+              LeaderHeads, EpicSpawners, UltimateStacker, WorldEdit, Residence, CoreProtect, CMIEInjector ]
+loadbefore: [ Multiverse-Core, ProtocolLib ]
 commands:
-    island:
-        description: Island command
-        aliases: [is]
-    skyblock:
-        description: Skyblock info command.
+  island:
+    description: Island command
+    aliases: [ is ]
+  skyblock:
+    description: Skyblock info command.


### PR DESCRIPTION
- added permission `fabledskyblock.island.level.rescan` that shows the rescan item in is level menu
- dodged a concurrent modification exception in cooldowns