### PR TITLE
Added "/island teleport" aliases setting

### DIFF
--- a/src/main/java/com/songoda/skyblock/command/commands/island/TeleportCommand.java
+++ b/src/main/java/com/songoda/skyblock/command/commands/island/TeleportCommand.java
@@ -43,6 +43,12 @@ public class TeleportCommand extends SubCommand {
                 messageManager.sendMessage(player, configLoad.getString("Command.Island.Teleport.Island.None.Message", "Command.Island.Teleport.Island.None.Message"));
                 soundManager.playSound(player, CompatibleSound.BLOCK_ANVIL_LAND.getSound(), 1.0F, 1.0F);
 
+                if (plugin.getIslandManager().getIsland(player) == null) {
+                    String commandToExecute = configLoad.getString("Command.IslandTeleport.Aliases.NoIsland", "");
+                    if (!commandToExecute.equals(""))
+                        Bukkit.dispatchCommand(player, commandToExecute);
+                }
+
                 return;
             }
             UUID islandOwnerUUID = island.getOwnerUUID();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,10 @@ Command:
         Aliases:
             IslandOwned: "island controlpanel"
             NoIsland: "island create"
+    IslandTeleport:
+        # What command should be executed on /island teleport
+        Aliases:
+            NoIsland: "island create"
 Sound:
     # When disabled all sounds will be disabled.
     Enable: true


### PR DESCRIPTION
If the command “/island teleport” is used by someone who doesn't own an island, it triggers an alias command. (default: "/island create")