### PR TITLE
Check if player is previewing an island before cleaning inventory

### DIFF
--- a/src/main/java/com/songoda/skyblock/command/commands/island/InformationCommand.java
+++ b/src/main/java/com/songoda/skyblock/command/commands/island/InformationCommand.java
@@ -59,6 +59,13 @@ public class InformationCommand extends SubCommand {
 
             PlayerData playerData = plugin.getPlayerDataManager().getPlayerData(player);
 
+            if (playerData.isPreview()) {
+                messageManager.sendMessage(player,
+                        configLoad.getString("Command.Island.Information.Previewing.Message"));
+                soundManager.playSound(player, CompatibleSound.BLOCK_ANVIL_LAND.getSound(), 1.0F, 1.0F);
+                return;
+            }
+
             if (islandOwnerUUID == null) {
                 if (islandManager.getIsland(player) == null) {
                     messageManager.sendMessage(player,

--- a/src/main/java/com/songoda/skyblock/island/IslandManager.java
+++ b/src/main/java/com/songoda/skyblock/island/IslandManager.java
@@ -580,10 +580,10 @@ public class IslandManager {
                 }
 
                 // TODO - Find a way to delete also offline players
-                if (configLoad.getBoolean("Island.Deletion.ClearInventory", false)){
+                if (configLoad.getBoolean("Island.Deletion.ClearInventory", false) && !playerData.isPreview()) {
                     player.getInventory().clear();
                 }
-                if (configLoad.getBoolean("Island.Deletion.ClearEnderChest", false)){
+                if (configLoad.getBoolean("Island.Deletion.ClearEnderChest", false) && !playerData.isPreview()) {
                     player.getEnderChest().clear();
                 }
 

--- a/src/main/resources/language.yml
+++ b/src/main/resources/language.yml
@@ -841,6 +841,8 @@ Command:
         Message: '&bSkyBlock &8| &cError&8: &eYou don''t have permission to view information on other players'' Islands.'
       Owner:
         Message: '&bSkyBlock &8| &cError&8: &eYou are not an Island Owner.'
+      Previewing:
+        Message: '&bSkyBlock &8| &cError&8: &eYou are currently previewing an island.'
       Info:
         Message: '&f&oOpens the Island Information menu.'
     Reset:


### PR DESCRIPTION
So someone reported that the preview mode cleared the inventory and ender chest when these options were enabled. So I added an additional check for preview mode, and also added it for the info command.