### PR TITLE
Fix maven-shade-plugin being missing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0-SNAPSHOT</version>
+                <version>3.3.0</version>
 
                 <executions>
                     <execution>
@@ -123,13 +123,6 @@
             </plugin>
         </plugins>
     </build>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>apache.snapshots</id>
-            <url>https://repository.apache.org/snapshots/</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <repositories>
         <repository>


### PR DESCRIPTION
Apache released maven-shade-plugin v3.3.0 some time ago on their stable repos, so the snapshots repository is no longer required.